### PR TITLE
Improve ValidDotNet validation consistency

### DIFF
--- a/src/Natron.AWS/Consumer/Batch.cs
+++ b/src/Natron.AWS/Consumer/Batch.cs
@@ -16,6 +16,11 @@ public class Batch
     public static Batch From(ILoggerFactory loggerFactory, CancellationToken cancellationToken, IAmazonSQS client,
         string queueUrl, IEnumerable<Amazon.SQS.Model.Message> rawMessages)
     {
+        loggerFactory.ThrowIfNull();
+        client.ThrowIfNull();
+        queueUrl.ThrowIfNullOrWhitespace();
+        rawMessages.ThrowIfNull();
+        
         var messages = rawMessages.Select(x => new Message(loggerFactory, cancellationToken, client, queueUrl, x))
             .ToList();
 

--- a/src/Natron.Http/Config.cs
+++ b/src/Natron.Http/Config.cs
@@ -31,6 +31,11 @@ public sealed class Config
 
     public void UseHealthChecks(params HealthCheck[] healthChecks)
     {
-        HealthChecks = healthChecks.ThrowIfNull().ToList();
+        healthChecks.ThrowIfNull();
+        foreach (var healthCheck in healthChecks)
+        {
+            healthCheck.ThrowIfNull();
+        }
+        HealthChecks = healthChecks.ToList();
     }
 }

--- a/src/Natron.Http/Middleware/ObservabilityMiddleware.cs
+++ b/src/Natron.Http/Middleware/ObservabilityMiddleware.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
 using System.Globalization;
-using ArgumentNullException = System.ArgumentNullException;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Prometheus;
+using ValidDotNet;
 
 namespace Natron.Http.Middleware;
 
@@ -14,7 +14,7 @@ public sealed class ObservabilityMiddleware
 
     public ObservabilityMiddleware(RequestDelegate next)
     {
-        _next = next ?? throw new ArgumentNullException(nameof(next));
+        _next = next.ThrowIfNull();
     }
 
     public async Task InvokeAsync(HttpContext context)

--- a/src/Natron.Kafka/Producer/Producer.cs
+++ b/src/Natron.Kafka/Producer/Producer.cs
@@ -12,7 +12,7 @@ public sealed class Producer<TKey, TValue> : IDisposable
     public Producer(ILoggerFactory loggerFactory, ProducerConfig producerConfig)
     {
         _logger = loggerFactory.ThrowIfNull().CreateLogger<Producer<TKey, TValue>>();
-        _producer = new ProducerBuilder<TKey, TValue>(producerConfig).Build();
+        _producer = new ProducerBuilder<TKey, TValue>(producerConfig.ThrowIfNull()).Build();
     }
 
     public void Dispose()
@@ -23,6 +23,8 @@ public sealed class Producer<TKey, TValue> : IDisposable
     public Task<DeliveryResult<TKey, TValue>> ProduceAsync(string topic, Message<TKey, TValue> message,
         CancellationToken cancellationToken = new())
     {
+        topic.ThrowIfNullOrWhitespace();
+        message.ThrowIfNull();
         return _producer.ProduceAsync(topic, message, cancellationToken);
     }
 }

--- a/src/Natron/ServiceBuilder.cs
+++ b/src/Natron/ServiceBuilder.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ValidDotNet;
 
 namespace Natron;
 
@@ -8,6 +9,9 @@ public sealed class ServiceBuilder
 
     private ServiceBuilder(string name, ILoggerFactory loggerFactory, CancellationTokenSource cts)
     {
+        name.ThrowIfNullOrWhitespace();
+        loggerFactory.ThrowIfNull();
+        cts.ThrowIfNull();
         _config = new ServiceConfig(name, loggerFactory, cts);
     }
 


### PR DESCRIPTION
## Summary

This PR addresses 6 ValidDotNet validation inconsistencies found during a comprehensive audit:

- **Kafka Producer constructor**: Added missing `producerConfig.ThrowIfNull()` validation (was validating `loggerFactory` but not `producerConfig`)
- **ServiceBuilder**: Added fail-fast validation for `name`, `loggerFactory`, and `cts` parameters (improves error stack traces by catching issues at builder creation rather than downstream in `ServiceConfig`)
- **Producer.ProduceAsync**: Added validation for `topic` and `message` parameters
- **Batch.From static factory**: Added validation for all 4 reference-type parameters (`loggerFactory`, `client`, `queueUrl`, `rawMessages`)
- **ObservabilityMiddleware**: Replaced manual `?? throw new ArgumentNullException()` with ValidDotNet's `ThrowIfNull()` for consistency
- **Config.UseHealthChecks**: Added per-element null check to match the validation pattern used in Kafka Config

## Testing

- ✅ `dotnet build` - successful
- ✅ `dotnet test --filter Category=Unit` - all 19 unit tests pass

## Impact

- Better fail-fast behavior with more accurate error messages
- Consistent validation patterns across the entire codebase
- Prevents potential NullReferenceExceptions at runtime